### PR TITLE
feat(colorize): add "include" and "exclude" config properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,9 @@
             "**/*.css",
             "**/*.scss",
             "**/*.less",
-            "**/*.md"
+            "**/*.md",
+            "**/*.mdx",
+            "**/*.json"
           ],
           "description": "Glob patterns that defines the files to search for. Only include files you need, DO NOT USE `{**/*.*}` for both performance and to avoid binary files."
         },
@@ -222,6 +224,7 @@
           "default": [
             "**/node_modules/**",
             "**/bower_components/**",
+            "**/dev-dist/**",
             "**/dist/**",
             "**/build/**",
             "**/html/**",
@@ -259,6 +262,53 @@
             "dot-before",
             "dot-after"
           ]
+        },
+        "veco.colorize.include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.vue",
+            "**/*.svelte",
+            "**/*.astro",
+            "**/*.html",
+            "**/*.css",
+            "**/*.scss",
+            "**/*.less",
+            "**/*.md",
+            "**/*.mdx",
+            "**/*.json"
+          ],
+          "description": "Glob patterns that defines the files to search for. Only include files you need, DO NOT USE `{**/*.*}` for both performance and to avoid binary files."
+        },
+        "veco.colorize.exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/node_modules/**",
+            "**/bower_components/**",
+            "**/dev-dist/**",
+            "**/dist/**",
+            "**/build/**",
+            "**/html/**",
+            "**/coverage/**",
+            "**/out/**",
+            "**/.vscode/**",
+            "**/.vscode-test/**",
+            "**/.github/**",
+            "**/_output/**",
+            "**/*.min.*",
+            "**/*.map",
+            "**/.next/**"
+          ],
+          "description": "Glob pattern that defines files and folders to exclude while listing annotations."
         }
       }
     },

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -35,6 +35,8 @@ export interface FileNestingDefaultConfig {
 export interface ColorizeDefaultConfig {
   enabled: boolean
   namedColor: boolean
+  include: string[]
+  exclude: string[]
   decorationType:
     | 'background'
     | 'foreground'
@@ -83,6 +85,8 @@ export const configs = {
     root: 'veco.colorize',
     enabled: 'enabled',
     namedColor: 'namedColor',
+    include: 'include',
+    exclude: 'exclude',
     decorationType: 'decorationType',
   },
 } as const
@@ -296,5 +300,44 @@ export const colorizeDefaultConfig = {
    * Decoration type to highlight the colors
    */
   decorationType: 'background',
+  /**
+   * Glob patterns that defines the files to search for. Only include files you need
+   */
+  include: [
+    '**/*.js',
+    '**/*.jsx',
+    '**/*.ts',
+    '**/*.tsx',
+    '**/*.vue',
+    '**/*.svelte',
+    '**/*.astro',
+    '**/*.html',
+    '**/*.css',
+    '**/*.scss',
+    '**/*.less',
+    '**/*.md',
+    '**/*.mdx',
+    '**/*.json',
+  ],
+  /**
+   * Glob pattern that defines files and folders to exclude while listing annotations.
+   */
+  exclude: [
+    '**/node_modules/**',
+    '**/bower_components/**',
+    '**/dev-dist/**',
+    '**/dist/**',
+    '**/build/**',
+    '**/html/**',
+    '**/coverage/**',
+    '**/out/**',
+    '**/.vscode/**',
+    '**/.vscode-test/**',
+    '**/.github/**',
+    '**/_output/**',
+    '**/*.min.*',
+    '**/*.map',
+    '**/.next/**',
+  ],
 } satisfies ColorizeDefaultConfig
 // #endregion

--- a/src/docs/colorize.md
+++ b/src/docs/colorize.md
@@ -24,6 +24,8 @@ To add or change keywords and other settings, <kbd>command</kbd> + <kbd>,</kbd> 
 interface ColorizeDefaultConfig {
   enabled: boolean
   namedColor: boolean
+  include: string[]
+  exclude: string[]
   decorationType:
     | 'background'
     | 'foreground'
@@ -46,5 +48,44 @@ const colorizeDefaultConfig = {
    * Decoration type to highlight the colors
    */
   decorationType: 'background',
+  /**
+   * Glob patterns that defines the files to search for. Only include files you need
+   */
+  include: [
+    '**/*.js',
+    '**/*.jsx',
+    '**/*.ts',
+    '**/*.tsx',
+    '**/*.vue',
+    '**/*.svelte',
+    '**/*.astro',
+    '**/*.html',
+    '**/*.css',
+    '**/*.scss',
+    '**/*.less',
+    '**/*.md',
+    '**/*.mdx',
+    '**/*.json',
+  ],
+  /**
+   * Glob pattern that defines files and folders to exclude while listing annotations.
+   */
+  exclude: [
+    '**/node_modules/**',
+    '**/bower_components/**',
+    '**/dev-dist/**',
+    '**/dist/**',
+    '**/build/**',
+    '**/html/**',
+    '**/coverage/**',
+    '**/out/**',
+    '**/.vscode/**',
+    '**/.vscode-test/**',
+    '**/.github/**',
+    '**/_output/**',
+    '**/*.min.*',
+    '**/*.map',
+    '**/.next/**',
+  ],
 } satisfies ColorizeDefaultConfig
 ```

--- a/src/docs/highlight.md
+++ b/src/docs/highlight.md
@@ -130,6 +130,7 @@ const highlightDefaultConfig = {
    */
   exclude: [
     '**/node_modules/**',
+    '**/dev-dist/**',
     '**/dist/**',
     '**/bower_components/**',
     '**/build/**',

--- a/src/utils/colorize.ts
+++ b/src/utils/colorize.ts
@@ -3,6 +3,7 @@ import vscode from 'vscode'
 import { state } from '../constants/globals'
 import { colorNames, colorsRegex } from '../constants/colorize'
 import { getColorizeConfig } from './config'
+import { isFileNameOk } from './helper'
 
 /**
  * decoration type mapper based on config property "decorationType"
@@ -100,15 +101,16 @@ function clearDecorations() {
  */
 export async function updateColors() {
   const { activeTextEditor, createTextEditorDecorationType } = vscode.window
+  const { enabled, namedColor, include, exclude } = getColorizeConfig()
 
-  if (!activeTextEditor)
+  // do not update colors, if user the opened file doesn't fulfill `include` and `exclude` config
+  if (!activeTextEditor || !isFileNameOk({ include, exclude, filename: activeTextEditor.document.fileName }))
     return
 
   // clear/dispose all decorations first
   clearDecorations()
 
   // do not update colors, if user disable it
-  const { enabled, namedColor } = getColorizeConfig()
   if (!enabled)
     return
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode'
 import type { ColorizeDefaultConfig, FileNestingDefaultConfig, HighlightDefaultConfig } from '../constants/config'
-import { configs, highlightDefaultConfig } from '../constants/config'
+import { colorizeDefaultConfig, configs, highlightDefaultConfig } from '../constants/config'
 
 /**
  * get user defined "veco.highlight" extension config (with default values)
@@ -58,11 +58,15 @@ export function getColorizeConfig() {
   const enabled = config.get<ColorizeDefaultConfig['enabled']>(configs.colorize.enabled)
   const namedColor = config.get<ColorizeDefaultConfig['namedColor']>(configs.colorize.namedColor)
   const decorationType = config.get<ColorizeDefaultConfig['decorationType']>(configs.colorize.decorationType)
+  const include = config.get(configs.colorize.include, colorizeDefaultConfig.include)
+  const exclude = config.get(configs.colorize.exclude, colorizeDefaultConfig.exclude)
 
   return {
     config,
     enabled,
     namedColor,
     decorationType,
+    include,
+    exclude,
   }
 }

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,5 +1,6 @@
 import process from 'node:process'
 import vscode from 'vscode'
+import { minimatch } from 'minimatch'
 import type { CustomDiagnosticSeverity } from '../constants/config'
 
 /**
@@ -93,6 +94,29 @@ export function generateRandomEmoji() {
  */
 export function getFilename(filename: string) {
   return filename.split('/').at(-1)
+}
+
+/**
+ * get paths based on the input `include` / `exclude` pattern config
+ */
+export function getPaths(patterns: Array<string>) {
+  return Array.isArray(patterns)
+    ? `{${patterns.join(',')},` + `}`
+    : (typeof patterns == 'string' ? patterns : '')
+}
+
+/**
+ * checks if the filename matches with the `include` / `exclude` config using `minimatch`
+ */
+export function isFileNameOk({ filename, include, exclude }: { include: string[], exclude: string[], filename: string }) {
+  const includePatterns = getPaths(include) || '{**/*}'
+  const excludePatterns = getPaths(exclude)
+
+  // converting glob expressions into JavaScript RegExp objects
+  const includeMatch = minimatch(filename, includePatterns)
+  const excludeMatch = minimatch(filename, excludePatterns)
+
+  return includeMatch && !excludeMatch
 }
 
 /**


### PR DESCRIPTION
- add `include` and `exclude` config properties based on #8
- move `isFileNameOk` and `getPaths` to `helper.ts`
- `include` and `exclude` in highlight and colorize module is the same for consistency
 