### PR TITLE
feat(packager): add "veco.packager.updateSingle" command, more ContextValue union types, target changed to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -424,7 +424,13 @@
         "title": "Update All Dependencies",
         "category": "Veco - Packager",
         "command": "veco.packager.updateAll",
-        "icon": "$(zap)"
+        "icon": "$(fold-up)"
+      },
+      {
+        "title": "Update Dependency",
+        "category": "Veco - Packager",
+        "command": "veco.packager.updateSingle",
+        "icon": "$(chevron-up)"
       }
     ],
     "keybindings": [
@@ -499,7 +505,12 @@
         {
           "command": "veco.packager.remove",
           "group": "inline",
-          "when": "viewItem == dependencies || viewItem == devDependencies"
+          "when": "viewItem == dependencies || viewItem == devDependencies || viewItem == updatableDependencies || viewItem == updatableDevDependencies"
+        },
+        {
+          "command": "veco.packager.updateSingle",
+          "group": "inline",
+          "when": "viewItem == updatableDependencies || viewItem == updatableDevDependencies"
         },
         {
           "command": "veco.packager.link",

--- a/src/commands/packager.ts
+++ b/src/commands/packager.ts
@@ -3,4 +3,5 @@ export const commandIds = {
   link: 'veco.packager.link',
   remove: 'veco.packager.remove',
   updateAll: 'veco.packager.updateAll',
+  updateSingle: 'veco.packager.updateSingle',
 } as const

--- a/src/constants/packager.ts
+++ b/src/constants/packager.ts
@@ -2,7 +2,7 @@ import type { RunOptions } from 'npm-check-updates'
 
 export const defaultCheckRunOptions: RunOptions = {
   dep: ['prod', 'dev'], // only "dependencies" and "devDependencies"
-  target: 'semver', // could be overridden with config properties
+  target: 'latest', // could be overridden with config properties
   install: 'never',
   concurrency: 16,
   cache: false, // do not use cache


### PR DESCRIPTION
#21 

- add "veco.packager.updateSingle" command
- more `ContextValue` union types
- run options `target` changed to `"latest"`, because there are some problems with `"semver"`