### PR TITLE
feat(packager): add "moduleTypes" and "versionTarget" config properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,29 @@
             "**/.next/**"
           ],
           "description": "Glob pattern that defines files and folders to exclude while listing annotations."
+        },
+        "veco.packager.moduleTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "prod",
+            "dev"
+          ],
+          "description": "Check one or more types of dependencies only. For most cases, you only need \"prod\" and \"dev\", because the more types you include, the more deep the dependencies will be shown"
+        },
+        "veco.packager.versionTarget": {
+          "type": "string",
+          "default": "latest",
+          "enum": [
+            "latest",
+            "newest",
+            "greatest",
+            "minor",
+            "patch"
+          ],
+          "description": "Determines the version to upgrade to."
         }
       }
     },
@@ -505,12 +528,12 @@
         {
           "command": "veco.packager.remove",
           "group": "inline",
-          "when": "viewItem == dependencies || viewItem == devDependencies || viewItem == updatableDependencies || viewItem == updatableDevDependencies"
+          "when": "viewItem == dependencies || viewItem == devDependencies || viewItem == peerDependencies || viewItem == optionalDependencies || viewItem == updatableDependencies || viewItem == updatableDevDependencies || viewItem == updatablePeerDependencies || viewItem == updatableOptionalDependencies"
         },
         {
           "command": "veco.packager.updateSingle",
           "group": "inline",
-          "when": "viewItem == updatableDependencies || viewItem == updatableDevDependencies"
+          "when": "viewItem == updatableDependencies || viewItem == updatableDevDependencies || viewItem == updatablePeerDependencies || viewItem == updatableOptionalDependencies"
         },
         {
           "command": "veco.packager.link",

--- a/src/commands/packager.ts
+++ b/src/commands/packager.ts
@@ -1,3 +1,7 @@
+import vscode from 'vscode'
+import type { DependencyTreeItem, NodeDependenciesProvider } from '../utils/packager'
+import { views } from '../constants/config'
+
 export const commandIds = {
   refreshEntry: 'veco.packager.refreshEntry',
   link: 'veco.packager.link',
@@ -5,3 +9,35 @@ export const commandIds = {
   updateAll: 'veco.packager.updateAll',
   updateSingle: 'veco.packager.updateSingle',
 } as const
+
+/**
+ * init all commands and register tree data provider
+ */
+export function initCommands(nodeDependenciesProvider: NodeDependenciesProvider) {
+  return [
+    vscode.window.registerTreeDataProvider(
+      views.veco_packager,
+      nodeDependenciesProvider,
+    ),
+    vscode.commands.registerCommand(
+      commandIds.refreshEntry,
+      () => nodeDependenciesProvider.refresh(),
+    ),
+    vscode.commands.registerCommand(
+      commandIds.link,
+      (dep?: DependencyTreeItem) => nodeDependenciesProvider.link(dep),
+    ),
+    vscode.commands.registerCommand(
+      commandIds.remove,
+      (dep?: DependencyTreeItem) => nodeDependenciesProvider.remove(dep),
+    ),
+    vscode.commands.registerCommand(
+      commandIds.updateAll,
+      () => nodeDependenciesProvider.updateAll(),
+    ),
+    vscode.commands.registerCommand(
+      commandIds.updateSingle,
+      (dep?: DependencyTreeItem) => nodeDependenciesProvider.updateSingle(dep),
+    ),
+  ]
+}

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -45,6 +45,16 @@ export interface ColorizeDefaultConfig {
     | 'dot-before'
     | 'dot-after'
 }
+
+export interface PackagerDefaultConfig {
+  moduleTypes: ('prod' | 'dev' | 'optional' | 'peer')[]
+  versionTarget:
+    | 'latest'
+    | 'newest'
+    | 'greatest'
+    | 'minor'
+    | 'patch'
+}
 // #endregion
 
 // #region CONSTANTS
@@ -88,6 +98,11 @@ export const configs = {
     include: 'include',
     exclude: 'exclude',
     decorationType: 'decorationType',
+  },
+  packager: {
+    root: 'veco.packager',
+    moduleTypes: 'moduleTypes',
+    versionTarget: 'versionTarget',
   },
 } as const
 
@@ -350,4 +365,26 @@ export const colorizeDefaultConfig = {
     '**/.next/**',
   ],
 } satisfies ColorizeDefaultConfig
+
+export const packagerDefaultConfig = {
+  /**
+   * Check one or more types of dependencies only
+   *
+   * - "prod": refers to "dependencies" in package.json
+   * - "dev": refers to "devDependencies" in package.json
+   * - "optional": refers to "optionalDependencies" in package.json
+   * - "peer": refers to "peerDependencies" in package.json
+   */
+  moduleTypes: ['prod', 'dev'],
+  /**
+   * Determines the version to upgrade to
+   *
+   * - "latest": Upgrade to whatever the package's "latest" git tag points to. Excludes prereleases.
+   * - "newest": Upgrade to the version with the most recent publish date, even if there are other version numbers that are higher. Includes prereleases.
+   * - "greatest": Upgrade to the highest version number published, regardless of release date or tag.
+   * - "minor": Upgrade to the highest minor version without bumping the major version.
+   * - "patch": Upgrade to the highest patch version without bumping the minor or major versions.
+   */
+  versionTarget: 'latest',
+} satisfies PackagerDefaultConfig
 // #endregion

--- a/src/constants/packager.ts
+++ b/src/constants/packager.ts
@@ -1,8 +1,9 @@
 import type { RunOptions } from 'npm-check-updates'
+import { packagerDefaultConfig } from './config'
 
 export const defaultCheckRunOptions: RunOptions = {
-  dep: ['prod', 'dev'], // only "dependencies" and "devDependencies"
-  target: 'latest', // could be overridden with config properties
+  dep: packagerDefaultConfig.moduleTypes,
+  target: packagerDefaultConfig.versionTarget,
   install: 'never',
   concurrency: 16,
   cache: false, // do not use cache

--- a/src/docs/packager.md
+++ b/src/docs/packager.md
@@ -1,6 +1,6 @@
 # Intro
 
-This module will make it easy to view, add, update, and delete your node dependencies easily within your vscode.
+This module will make it easy to list, add, update, delete, and view outdated node dependencies within your vscode.
 
 ## Commands
 
@@ -9,6 +9,46 @@ This extension contributes the following commands to the Command palette.
 - `veco.packager.refreshEntry`: Refresh the node dependencies that displayed in the "Packager: Node Dependencies" view.
 - `veco.packager.link`: Open/link the module dependency to external NPM website.
 - `veco.packager.remove`: Uninstall/remove the selected module dependency.
+- `veco.packager.updateAll`: Update all outdated module dependencies.
+- `veco.packager.updateSingle`: Update single outdated module dependency.
+
+## Configurations
+
+To add or change keywords and other settings, <kbd>command</kbd> + <kbd>,</kbd> (or on Windows / Linux: File -> Preferences -> User Settings) to open the VSCode file `settings.json`.
+
+```ts
+export interface PackagerDefaultConfig {
+  moduleTypes: ('prod' | 'dev' | 'optional' | 'peer')[]
+  versionTarget:
+    | 'latest'
+    | 'newest'
+    | 'greatest'
+    | 'minor'
+    | 'patch'
+}
+
+export const packagerDefaultConfig = {
+  /**
+   * Check one or more types of dependencies only
+   *
+   * - "prod": refers to "dependencies" in package.json
+   * - "dev": refers to "devDependencies" in package.json
+   * - "optional": refers to "optionalDependencies" in package.json
+   * - "peer": refers to "peerDependencies" in package.json
+   */
+  moduleTypes: ['prod', 'dev'],
+  /**
+   * Determines the version to upgrade to
+   *
+   * - "latest": Upgrade to whatever the package's "latest" git tag points to. Excludes prereleases.
+   * - "newest": Upgrade to the version with the most recent publish date, even if there are other version numbers that are higher. Includes prereleases.
+   * - "greatest": Upgrade to the highest version number published, regardless of release date or tag.
+   * - "minor": Upgrade to the highest minor version without bumping the major version.
+   * - "patch": Upgrade to the highest patch version without bumping the minor or major versions.
+   */
+  versionTarget: 'latest',
+} satisfies PackagerDefaultConfig
+```
 
 ## Inspirations
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode'
-import type { ColorizeDefaultConfig, FileNestingDefaultConfig, HighlightDefaultConfig } from '../constants/config'
-import { colorizeDefaultConfig, configs, highlightDefaultConfig } from '../constants/config'
+import type { ColorizeDefaultConfig, FileNestingDefaultConfig, HighlightDefaultConfig, PackagerDefaultConfig } from '../constants/config'
+import { colorizeDefaultConfig, configs, highlightDefaultConfig, packagerDefaultConfig } from '../constants/config'
 
 /**
  * get user defined "veco.highlight" extension config (with default values)
@@ -68,5 +68,20 @@ export function getColorizeConfig() {
     decorationType,
     include,
     exclude,
+  }
+}
+
+/**
+ * get user defined "veco.packager" extension config
+ */
+export function getPackagerConfig() {
+  const config = vscode.workspace.getConfiguration(configs.packager.root)
+  const moduleTypes = config.get<PackagerDefaultConfig['moduleTypes']>(configs.packager.moduleTypes, packagerDefaultConfig.moduleTypes)
+  const versionTarget = config.get<PackagerDefaultConfig['versionTarget']>(configs.packager.versionTarget, packagerDefaultConfig.versionTarget)
+
+  return {
+    config,
+    moduleTypes,
+    versionTarget,
   }
 }


### PR DESCRIPTION
#21 

- add "moduleTypes" and "versionTarget" config properties (now supports `"peer"` and `"optional"` dependencies)
- move `init` function from utils to commands
- add more unions to `ContextValue`