### PR TITLE
fix(packager): bump ncu, versionTarget now defaults to "semver"

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,8 +329,9 @@
         },
         "veco.packager.versionTarget": {
           "type": "string",
-          "default": "latest",
+          "default": "semver",
           "enum": [
+            "semver",
             "latest",
             "newest",
             "greatest",
@@ -567,7 +568,7 @@
     "esno": "^4.0.0",
     "lint-staged": "^15.1.0",
     "minimatch": "^9.0.3",
-    "npm-check-updates": "^16.14.11",
+    "npm-check-updates": "^16.14.12",
     "pnpm": "^8.11.0",
     "prettier": "^3.1.0",
     "rimraf": "^5.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^9.0.3
         version: 9.0.3
       npm-check-updates:
-        specifier: ^16.14.11
-        version: 16.14.11
+        specifier: ^16.14.12
+        version: 16.14.12
       pnpm:
         specifier: ^8.11.0
         version: 8.11.0
@@ -4095,8 +4095,8 @@ packages:
       npm-normalize-package-bin: 3.0.1
     dev: true
 
-  /npm-check-updates@16.14.11:
-    resolution: {integrity: sha512-0MMWGbGci22Pu77bR9jRsy5qgxdQSJVqNtSyyFeubDPtbcU36z4gjEDITu26PMabFWPNkAoVfKF31M3uKUvzFg==}
+  /npm-check-updates@16.14.12:
+    resolution: {integrity: sha512-5FvqaDX8AqWWTDQFbBllgLwoRXTvzlqVIRSKl9Kg8bYZTfNwMnrp1Zlmb5e/ocf11UjPTc+ShBFjYQ7kg6FL0w==}
     engines: {node: '>=14.14'}
     hasBin: true
     dependencies:

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -49,6 +49,7 @@ export interface ColorizeDefaultConfig {
 export interface PackagerDefaultConfig {
   moduleTypes: ('prod' | 'dev' | 'optional' | 'peer')[]
   versionTarget:
+    | 'semver'
     | 'latest'
     | 'newest'
     | 'greatest'
@@ -379,12 +380,13 @@ export const packagerDefaultConfig = {
   /**
    * Determines the version to upgrade to
    *
+   * - "semver": Upgrade to the highest version within the semver range specified in your package.json
    * - "latest": Upgrade to whatever the package's "latest" git tag points to. Excludes prereleases.
    * - "newest": Upgrade to the version with the most recent publish date, even if there are other version numbers that are higher. Includes prereleases.
    * - "greatest": Upgrade to the highest version number published, regardless of release date or tag.
    * - "minor": Upgrade to the highest minor version without bumping the major version.
    * - "patch": Upgrade to the highest patch version without bumping the minor or major versions.
    */
-  versionTarget: 'latest',
+  versionTarget: 'semver',
 } satisfies PackagerDefaultConfig
 // #endregion


### PR DESCRIPTION
#21 

- bump `npm-check-updates` which patches the "target === semver" bug
- `versionTarget` now defaults to `"semver"`