### PR TITLE
feat(packager): add viewsWelcome when the tree data provider empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -514,6 +514,12 @@
         "mac": "ctrl+m ctrl+a"
       }
     ],
+    "viewsWelcome": [
+      {
+        "view": "veco_packager.treeDataProvider",
+        "contents": "In order to use packager features, you can open a folder containing a 'package.json' file or initialize it by clicking button below.\n[Initialize package.json](command:veco.packager.init)\nClick on the refresh button after you have initialized the 'package.json'."
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/src/commands/packager.ts
+++ b/src/commands/packager.ts
@@ -1,6 +1,7 @@
 import vscode from 'vscode'
 import type { DependencyTreeItem, NodeDependenciesProvider } from '../utils/packager'
 import { views } from '../constants/config'
+import { executeCommand } from '../utils/helper'
 
 export const commandIds = {
   refreshEntry: 'veco.packager.refreshEntry',
@@ -8,7 +9,16 @@ export const commandIds = {
   remove: 'veco.packager.remove',
   updateAll: 'veco.packager.updateAll',
   updateSingle: 'veco.packager.updateSingle',
+  init: 'veco.packager.init',
 } as const
+
+/**
+ * initialize `package.json` file in the root directory
+ */
+function initPackageJson() {
+  const cmd = 'npm init --yes'
+  executeCommand(cmd)
+}
 
 /**
  * init all commands and register tree data provider
@@ -38,6 +48,10 @@ export function initCommands(nodeDependenciesProvider: NodeDependenciesProvider)
     vscode.commands.registerCommand(
       commandIds.updateSingle,
       (dep?: DependencyTreeItem) => nodeDependenciesProvider.updateSingle(dep),
+    ),
+    vscode.commands.registerCommand(
+      commandIds.init,
+      () => initPackageJson(),
     ),
   ]
 }

--- a/src/utils/packager.ts
+++ b/src/utils/packager.ts
@@ -121,7 +121,7 @@ export class NodeDependenciesProvider implements vscode.TreeDataProvider<Depende
     const packageJsonStat = await this.checkFileExists(packageJsonUri)
 
     if (!packageJsonStat) {
-      vscode.window.showInformationMessage('Workspace has no "package.json" file')
+      vscode.window.showInformationMessage('There is no "package.json" file in the workspace')
       return []
     }
 


### PR DESCRIPTION
#34

- add viewsWelcome when the tree data provider empty
- add init package.json command